### PR TITLE
Use full <?php tags in place of short open tags

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,4 +1,4 @@
-<?
+<?php
 	define('ENGINE_PATH', '../dbWebGen/');
 	define('DBWEBGEN_LANG', 'de');
 	include ENGINE_PATH . 'engine.php';

--- a/plugin.php
+++ b/plugin.php
@@ -1,4 +1,4 @@
-<?
+<?php
 	//------------------------------------------------------------------------------------------
 	// registered via $APP['render_main_page_proc']
 	function demo_main_page() {


### PR DESCRIPTION
Short open tags deprecated from 2019-07-23 (https://wiki.php.net/rfc/deprecate_php_short_tags_v2)